### PR TITLE
Update dependency webpack to v4.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bs-easy-format": "0.1.0",
     "bs-json": "1.0.1",
     "bs-platform": "2.2.3",
-    "webpack": "4.16.2",
+    "webpack": "4.16.3",
     "webpack-cli": "3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4391,9 +4391,9 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.16.2:
-  version "4.16.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.16.2.tgz#c3e0e771adc94582e0543dd18d7436066051e885"
+webpack@4.16.3:
+  version "4.16.3"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.16.3.tgz#861be3176d81e7e3d71c66c8acc9bba35588b525"
   dependencies:
     "@webassemblyjs/ast" "1.5.13"
     "@webassemblyjs/helper-module-context" "1.5.13"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/webpack/webpack">webpack</a> from <code>v4.16.2</code> to <code>v4.16.3</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v4163httpsgithubcomwebpackwebpackreleasesv4163"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.16.3"><code>v4.16.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.16.2…v4.16.3">Compare Source</a></p>
<h3 id="bugfixes">Bugfixes</h3>
<ul>
<li>fix missing modules with chunks nested in unneeded <code>require.ensure</code>s.</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>