### PR TITLE
Update dependency flow-bin to ^0.80.0

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "devDependencies": {},
   "dependencies": {
-    "flow-bin": "^0.79.0",
+    "flow-bin": "^0.80.0",
     "typescript": "^2.7.0-dev.20171027"
   }
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-flow-bin@^0.79.0:
-  version "0.79.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.79.0.tgz#a7029f2832d45e5b78f7e77a74fee898722fb6ef"
+flow-bin@^0.80.0:
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.80.0.tgz#04cc1ee626a6f50786f78170c92ebe1745235403"
 
 typescript@^2.7.0-dev.20171027:
   version "2.7.0-dev.20171027"


### PR DESCRIPTION
<p>This Pull Request updates dependency <code>flow-bin</code> (<a href="https://renovatebot.com/gh/flowtype/flow-bin">source</a>) from <code>^0.79.0</code> to <code>^0.80.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v0800httpsgithubcomflowtypeflow-bincomparev0791v0800"><a href="https://renovatebot.com/gh/flowtype/flow-bin/compare/v0.79.1…v0.80.0"><code>v0.80.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/flowtype/flow-bin/compare/v0.79.1…v0.80.0">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>