### PR TITLE
Update dependency webpack to v4.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bs-easy-format": "0.1.0",
     "bs-json": "1.0.1",
     "bs-platform": "2.2.3",
-    "webpack": "4.17.1",
+    "webpack": "4.17.2",
     "webpack-cli": "3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4422,16 +4422,23 @@ webpack-cli@3.1.0:
     v8-compile-cache "^2.0.0"
     yargs "^12.0.1"
 
-webpack-sources@^1.0.1, webpack-sources@^1.1.0:
+webpack-sources@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.1.0.tgz#a101ebae59d6507354d71d8013950a3a8b7a5a54"
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.17.1:
-  version "4.17.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.17.1.tgz#0f026e3d823f3fc604f811ed3ea8f0d9b267fb1e"
+webpack-sources@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.2.0.tgz#18181e0d013fce096faf6f8e6d41eeffffdceac2"
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
+
+webpack@4.17.2:
+  version "4.17.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.17.2.tgz#49feb20205bd15f0a5f1fe0a12097d5d9931878d"
   dependencies:
     "@webassemblyjs/ast" "1.5.13"
     "@webassemblyjs/helper-module-context" "1.5.13"
@@ -4457,7 +4464,7 @@ webpack@4.17.1:
     tapable "^1.0.0"
     uglifyjs-webpack-plugin "^1.2.4"
     watchpack "^1.5.0"
-    webpack-sources "^1.0.1"
+    webpack-sources "^1.2.0"
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>webpack</code> (<a href="https://renovatebot.com/gh/webpack/webpack">source</a>) from <code>v4.17.1</code> to <code>v4.17.2</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v4172httpsgithubcomwebpackwebpackreleasesv4172"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.17.2"><code>v4.17.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.17.1…v4.17.2">Compare Source</a></p>
<h3 id="bugfixes">Bugfixes</h3>
<ul>
<li>fix a spacing issue with the ProgressPlugin on some terminals</li>
<li>force-upgrade webpack-sources for performance improvement (was already in semver range)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>