### PR TITLE
Update dependency webpack to v4.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bs-cmdliner": "0.1.0",
     "bs-easy-format": "0.1.0",
     "bs-platform": "4.0.5",
-    "webpack": "4.17.2",
+    "webpack": "4.17.3",
     "webpack-cli": "3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4436,9 +4436,9 @@ webpack-sources@^1.2.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.17.2:
-  version "4.17.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.17.2.tgz#49feb20205bd15f0a5f1fe0a12097d5d9931878d"
+webpack@4.17.3:
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.17.3.tgz#ef61909c580d10dfc0f4ed491da2d30f0f4b05ce"
   dependencies:
     "@webassemblyjs/ast" "1.5.13"
     "@webassemblyjs/helper-module-context" "1.5.13"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>webpack</code> (<a href="https://renovatebot.com/gh/webpack/webpack">source</a>) from <code>v4.17.2</code> to <code>v4.17.3</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v4173httpsgithubcomwebpackwebpackreleasesv4173"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.17.3"><code>v4.17.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.17.2…v4.17.3">Compare Source</a></p>
<h3 id="bugfixes">Bugfixes</h3>
<ul>
<li>Fix exit code when multiple CLIs are installed</li>
<li>No longer recommend installing webpack-command, but still support it when installed</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>