### PR TITLE
Update Node.js to v8.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 references:
   docker_container_of_nodejs: &docker_container_of_nodejs
     docker:
-      - image: circleci/node:8.11.4
+      - image: circleci/node:8.12.0
     working_directory: ~/typed_i18n
   install_yarn: &install_yarn
     run:


### PR DESCRIPTION
<p>This Pull Request updates Docker base image <code>circleci/node</code> from tag <code>8.11.4</code> to new tag <code>8.12.0</code>. For details on Renovate's Docker support, please visit <a href="https://renovatebot.com/docs/docker">https://renovatebot.com/docs/docker</a></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>