### PR TITLE
Update dependency @glennsl/bs-jest to v0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/kogai/typed_i18n#readme",
   "devDependencies": {
-    "@glennsl/bs-jest": "0.4.3",
+    "@glennsl/bs-jest": "0.4.4",
     "@glennsl/bs-json": "2.0.0",
     "bs-cmdliner": "0.1.0",
     "bs-easy-format": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@glennsl/bs-jest@0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@glennsl/bs-jest/-/bs-jest-0.4.3.tgz#692d822a4ae02f10e534ad0defe7b8f96854af44"
+"@glennsl/bs-jest@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@glennsl/bs-jest/-/bs-jest-0.4.4.tgz#71cd14217023efd14e09f0030c08f2103e90d734"
   dependencies:
     jest "^23.5.0"
 


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>@glennsl/bs-jest</code> (<a href="https://renovatebot.com/gh/glennsl/bs-jest">source</a>) from <code>v0.4.3</code> to <code>v0.4.4</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v044httpsgithubcomglennslbs-jestcomparev043v044"><a href="https://renovatebot.com/gh/glennsl/bs-jest/compare/v0.4.3…v0.4.4"><code>v0.4.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/glennsl/bs-jest/compare/v0.4.3…v0.4.4">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>