### PR TITLE
Update dependency webpack to v4.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bs-cmdliner": "0.1.0",
     "bs-easy-format": "0.1.0",
     "bs-platform": "4.0.5",
-    "webpack": "4.19.0",
+    "webpack": "4.19.1",
     "webpack-cli": "3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4429,9 +4429,9 @@ webpack-sources@^1.2.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.19.0:
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.19.0.tgz#252296c8af2d21c0994911007defdb3913a7bc66"
+webpack@4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.19.1.tgz#096674bc3b573f8756c762754366e5b333d6576f"
   dependencies:
     "@webassemblyjs/ast" "1.7.6"
     "@webassemblyjs/helper-module-context" "1.7.6"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>webpack</code> (<a href="https://renovatebot.com/gh/webpack/webpack">source</a>) from <code>v4.19.0</code> to <code>v4.19.1</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v4191httpsgithubcomwebpackwebpackreleasesv4191"><a href="https://renovatebot.com/gh/webpack/webpack/releases/v4.19.1"><code>v4.19.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/webpack/webpack/compare/v4.19.0…v4.19.1">Compare Source</a></p>
<h3 id="bugfixes">Bugfixes</h3>
<ul>
<li>Internal requested filename for <code>import()</code> with <code>target: "electron-main"</code> uses correct path separator on windows<br />
(This fixes a problem with filemappings in vscode)</li>
<li><code>devtool: "source-map"</code> and variants generate SourceMaps when output file is <code>.mjs</code></li>
<li><code>browser</code> field as object is used when using <code>target: "electron-renderer"</code></li>
<li>Comments near <code>export default</code> are preserved</li>
<li>Passing an array as <code>externals</code> value, now works correctly as documented</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>