### PR TITLE
:sparkles: Attempt to introduce new option max_depth

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@glennsl/bs-json": "3.0.0",
     "bs-cmdliner": "0.1.0",
     "bs-easy-format": "0.1.0",
-    "bs-platform": "5.0.0",
+    "bs-platform": "5.0.1",
     "webpack": "4.29.6",
     "webpack-cli": "3.3.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -708,9 +708,9 @@ bs-easy-format@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/bs-easy-format/-/bs-easy-format-0.1.0.tgz#4dbc100a19ee06190b34183a336e6892fd460ed9"
 
-bs-platform@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.0.tgz#f9fded818bafc3891aeb85eb4e0d95b8d8f8b4d7"
+bs-platform@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.1.tgz#0e7a50a1b51896d3ff4e1df6e79d32530ba062f5"
 
 bser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What this PR is

Since Flow updating its version to 0.86.0, type definitions which typed_i18n generates make it hangs up due to its huge size of type variant.

I believe it's up to Flow and its type system,  and it already reported at https://github.com/facebook/flow/issues/5831 , but as usual, Flow team does not respond anyway.

Therefore, because of the problem caused by the total size of function definitions, I introduce `max_depth` option to typed_i18n which prevent to generate function definitions which its string literal type argument at most max_depth. 

For example, if max_depth as 2, typed_i18n generate type definitions like below 

```js
// From dictionaly as below
{
  "a": {
    "b": {
      "c": "my-word"
    }
  }
}

// To type definitions like below
declare function t(_: "a", _?: {}): {...}
declare function t(_: "a.b", _?: {}): {...}
// Definition like this will not generate 👉declare function t(_: "a.b.c", _?: {}): {...}
```

I know that isn't an ideal solution but may work pragmatically.

## Note

Also closes #81